### PR TITLE
Cast string to prevent error when load value from environment

### DIFF
--- a/src/DB/Database.php
+++ b/src/DB/Database.php
@@ -54,7 +54,7 @@ class Database
         $config->setMiddlewares([$logMiddleware]);
 
         $this->connection[self::DB_LOCAL] = DriverManager::getConnection([
-            'url' => getenv('DB_URL'),
+            'url' => (string) getenv('DB_URL'),
         ], $config);
 
         $configOrm = ORMSetup::createAttributeMetadataConfiguration(['src/DB/Entity']);
@@ -66,7 +66,7 @@ class Database
         );
 
         $this->connection[self::DB_AKAUNTING] = DriverManager::getConnection([
-            'url' => getenv('DB_URL_AKAUNTING'),
+            'url' => (string) getenv('DB_URL_AKAUNTING'),
         ], $config);
     }
 


### PR DESCRIPTION
the function getenv could return null value