### PR TITLE
Movendo logs de debug para info

### DIFF
--- a/src/Service/Akaunting/Source/Categories.php
+++ b/src/Service/Akaunting/Source/Categories.php
@@ -63,7 +63,7 @@ class Categories
         if (!empty($this->list)) {
             return $this->list;
         }
-        $this->logger->debug('Baixando dados de impostos');
+        $this->logger->info('Baixando dados de impostos');
 
         $list = $this->dataset->list('/api/categories', [
             'company_id' => $this->getCompanyId(),

--- a/src/Service/Akaunting/Source/Documents.php
+++ b/src/Service/Akaunting/Source/Documents.php
@@ -67,7 +67,7 @@ class Documents
         if (isset($this->list[$this->getType()])) {
             return $this->list[$this->getType()];
         }
-        $this->logger->debug('Baixando dados de invoices');
+        $this->logger->info('Baixando dados de invoices');
 
         $begin = (clone $this->getDate())
             ->modify('first day of this month');

--- a/src/Service/Akaunting/Source/Taxes.php
+++ b/src/Service/Akaunting/Source/Taxes.php
@@ -63,7 +63,7 @@ class Taxes
         if (!empty($this->list)) {
             return $this->list;
         }
-        $this->logger->debug('Baixando dados de impostos');
+        $this->logger->info('Baixando dados de impostos');
 
         $list = $this->dataset->list('/api/taxes', [
             'company_id' => $this->getCompanyId(),

--- a/src/Service/Akaunting/Source/Transactions.php
+++ b/src/Service/Akaunting/Source/Transactions.php
@@ -66,7 +66,7 @@ class Transactions
         if (!empty($this->list)) {
             return $this->list;
         }
-        $this->logger->debug('Baixando dados de transactions');
+        $this->logger->info('Baixando dados de transactions');
         $begin = $this->getDate()
             ->modify('first day of this month');
         $today = new DateTime();

--- a/src/Service/Kimai/Source/Customers.php
+++ b/src/Service/Kimai/Source/Customers.php
@@ -45,7 +45,7 @@ class Customers
 
     public function updateDatabase(): self
     {
-        $this->logger->debug('Baixando dados de customers');
+        $this->logger->info('Baixando dados de customers');
         $this->getFromApi();
         $this->saveList();
         return $this;

--- a/src/Service/Kimai/Source/Projects.php
+++ b/src/Service/Kimai/Source/Projects.php
@@ -47,9 +47,10 @@ class Projects
 
     public function updateDatabase(): void
     {
-        $this->logger->debug('Baixando dados de projects');
+        $this->logger->info('Baixando dados de projects');
         $this->getFromApi();
         $this->saveList($this->list);
+        $this->logger->info('Dados de projetos salvos com sucesso. Total: {total}', ['total' => $this->list]);
     }
 
     public function getFromApi(): array

--- a/src/Service/Kimai/Source/Timesheets.php
+++ b/src/Service/Kimai/Source/Timesheets.php
@@ -45,7 +45,7 @@ class Timesheets
 
     public function updateDatabase(DateTime $data): void
     {
-        $this->logger->debug('Baixando dados de timesheets');
+        $this->logger->info('Baixando dados de timesheets');
         $list = $this->getFromApi($data);
         $this->saveList($list);
     }

--- a/src/Service/Kimai/Source/Users.php
+++ b/src/Service/Kimai/Source/Users.php
@@ -74,7 +74,7 @@ class Users
         if (!empty($this->list)) {
             return $this->list;
         }
-        $this->logger->debug('Importando usuários com visibilidade = {visibilidade}', [
+        $this->logger->info('Importando usuários com visibilidade = {visibilidade}', [
             'visibilidade' => $this->visibilityDataset[$this->visibility],
         ]);
         $list = $this->doRequestKimai('/api/users', [
@@ -85,13 +85,13 @@ class Users
                 $user = $this->fromArray($row);
                 $this->list[] = $user;
             } catch (\Throwable $th) {
-                $this->logger->debug('Falha ao salvar dados de usuário', [
+                $this->logger->info('Falha ao salvar dados de usuário', [
                     'message' => $th->getMessage(),
                     'data' => $row,
                 ]);
             }
         }
-        $this->logger->debug('Dados baixados: {json}', ['json' => json_encode($list)]);
+        $this->logger->info('Dados baixados: {json}', ['json' => json_encode($list)]);
         return $list;
     }
 

--- a/src/Service/ProducaoCooperativista.php
+++ b/src/Service/ProducaoCooperativista.php
@@ -164,7 +164,7 @@ class ProducaoCooperativista
     public function loadFromExternalSources(DateTime $inicio): void
     {
         $this->dates->setInicio($inicio);
-        $this->logger->debug('Baixando dados externos');
+        $this->logger->info('Baixando dados externos');
         $this->customers->updateDatabase();
         $this->nfse->updateDatabase($this->dates->getInicioProximoMes());
         $this->projects->updateDatabase();
@@ -209,7 +209,7 @@ class ProducaoCooperativista
             'fim' => $this->dates->getFim()->format('Y-m-d H:i:s'),
         ]);
         $this->totalSegundosLibreCode = (int) $result->fetchOne();
-        $this->logger->debug('Total segundos LibreCode: {total}', ['total' => $this->totalSegundosLibreCode]);
+        $this->logger->info('Total segundos LibreCode: {total}', ['total' => $this->totalSegundosLibreCode]);
         return $this->totalSegundosLibreCode;
     }
 
@@ -249,7 +249,7 @@ class ProducaoCooperativista
             throw new Exception($messagem);
         }
         $this->totalCooperados = (int) $result;
-        $this->logger->debug('Total pessoas no mês: {total}', ['total' => $this->totalCooperados]);
+        $this->logger->info('Total pessoas no mês: {total}', ['total' => $this->totalCooperados]);
         return $this->totalCooperados;
     }
 
@@ -275,7 +275,7 @@ class ProducaoCooperativista
             return false;
         });
         $this->totalDispendios = array_reduce($dispendios, fn ($total, $i) => $total += $i['amount'], 0);
-        $this->logger->debug('Total dispêndios: {total}', ['total' => $this->totalDispendios]);
+        $this->logger->info('Total dispêndios: {total}', ['total' => $this->totalDispendios]);
         return $this->totalDispendios;
     }
 
@@ -400,7 +400,7 @@ class ProducaoCooperativista
             $total += $row['amount'];
             return $total;
         }, 0);
-        $this->logger->debug('Total custos clientes: {total}', ['total' => $this->totalCustoCliente]);
+        $this->logger->info('Total custos clientes: {total}', ['total' => $this->totalCustoCliente]);
         return $this->totalCustoCliente;
     }
 

--- a/src/Service/Source/Nfse.php
+++ b/src/Service/Source/Nfse.php
@@ -89,7 +89,7 @@ class Nfse
 
     public function updateDatabase(DateTime $data): void
     {
-        $this->logger->debug('Baixando dados de nfse');
+        $this->logger->info('Baixando dados de nfse');
         $list = $this->getFromApi($data);
         $this->saveList($list);
     }


### PR DESCRIPTION
Logs que não trazem um json enorme foram movidos para info para poder exibir no front

A ideia é mais a frente no desenvolvimento ter como retornar para o front os logs do tipo info.