### PR TITLE
Executa cálculos mesmo sem um tipo de saída

### DIFF
--- a/src/Command/MakeProducaoCommand.php
+++ b/src/Command/MakeProducaoCommand.php
@@ -118,6 +118,8 @@ class MakeProducaoCommand extends BaseCommand
         $this->producaoCooperativista->dates->setDiasUteis($diasUteis);
         $this->producaoCooperativista->setPercentualMaximo($percentualMaximo);
 
+        $this->producaoCooperativista->getProducaoCooperativista();
+
         if ($input->getOption('atualiza-producao')) {
             $this->producaoCooperativista->updateProducao();
         }


### PR DESCRIPTION
O método chamado precisa sempre ser executado para que os cálculos sejam feitos e seja possível coletar os dados calculados.