### PR TITLE
Correção em condições de início e fim

### DIFF
--- a/src/Service/ProducaoCooperativista.php
+++ b/src/Service/ProducaoCooperativista.php
@@ -491,16 +491,13 @@ class ProducaoCooperativista
             ->where(
                 $projetosAtivosNoMes->expr()->or(
                     'p.start IS NULL',
-                    $projetosAtivosNoMes->expr()->and(
-                        $projetosAtivosNoMes->expr()->gte('p.start', $qb->createNamedParameter($this->dates->getInicio()->format('Y-m-d'))),
-                        $projetosAtivosNoMes->expr()->lte('p.start', $qb->createNamedParameter($this->dates->getFim()->format('Y-m-d  H:i:s')))
-                    )
+                    $projetosAtivosNoMes->expr()->lte('p.start', $qb->createNamedParameter($this->dates->getFim()->format('Y-m-d H:i:s')))
                 )
             )
             ->andWhere(
                 $projetosAtivosNoMes->expr()->or(
                     'p.end IS NULL',
-                    $projetosAtivosNoMes->expr()->lte('p.end', $qb->createNamedParameter($this->dates->getFim()->format('Y-m-d H:i:s')))
+                    $projetosAtivosNoMes->expr()->gte('p.end', $qb->createNamedParameter($this->dates->getInicio()->format('Y-m-d')))
                 )
             )
             ->groupBy('c.id');


### PR DESCRIPTION
Condição necessária:

- Não tem data início ou data início é menor ou igual que data fim
- Não tem data fim ou data fim é maior igual que início

A condição anterior estava com exigência de data início no intervalo informado. Um projeto que iniciou antes do intervalo não estava sendo exibido. O mesmo vale para a data fim.