### PR TITLE
Troca de nome de coluna e de valor de campo

### DIFF
--- a/resources/view/layout/components/datatable.html.twig
+++ b/resources/view/layout/components/datatable.html.twig
@@ -171,7 +171,7 @@
                                 input.addEventListener('keyup', () => {
                                     window.history.pushState({}, "", linkify.link())
 
-                                    if (column.search() !== this.value) {
+                                    if (column.search() !== input.value) {
                                         column.search(input.value).draw()
                                     }
                                 })

--- a/src/Service/ProducaoCooperativista.php
+++ b/src/Service/ProducaoCooperativista.php
@@ -931,7 +931,7 @@ class ProducaoCooperativista
                 $this->urlGenerator->generate('Invoices#index', [
                     'ano-mes' => $this->dates->getInicio()->format('Y-m'),
                     'entrada_cliente' => 'sim',
-                    'type' => 'invoice',
+                    'category_type' => 'income',
                 ]) .
                 '">notas clientes</a>'
             ],
@@ -942,7 +942,7 @@ class ProducaoCooperativista
                 $this->urlGenerator->generate('Invoices#index', [
                     'ano-mes' => $this->dates->getInicio()->format('Y-m'),
                     'entrada_cliente' => 'sim',
-                    'type' => 'bill',
+                    'category_type' => 'income',
                 ]) .
                 '">dispêndios clientes</a>'
             ],


### PR DESCRIPTION
Após a troca da query, o conteúdo da coluna tipo passou a conter mais de um valor para o mesmo tipo, o que inviabilizou o uso dela para este filtro. O filtro foi trocado para ser aplicado em cima do tipo da categoria.