### PR TITLE
Feito clone para evitar mutação da data

### DIFF
--- a/src/Service/Akaunting/Document/FRRA.php
+++ b/src/Service/Akaunting/Document/FRRA.php
@@ -50,7 +50,7 @@ class FRRA extends ProducaoCooperativista
                 $this->whoami . '_' .
                 $cooperado->getTaxNumber() .
                 '-' .
-                $this->dates->getPrevisaoPagamentoFrra()
+                (clone $this->dates->getPrevisaoPagamentoFrra())
                     ->modify('-2 month')
                     ->format('Y-m')
             );


### PR DESCRIPTION
O modify altera o objeto e para que o original não seja alterado foi preciso fazer um clone.