### PR TITLE
Testes no cálculo do INSS

### DIFF
--- a/src/Service/INSS.php
+++ b/src/Service/INSS.php
@@ -30,15 +30,16 @@ class INSS
     private float $baseMaxima = 7087.22;
     private float $aliquotaProducaoInterna = 0.10;
     private float $aliquotaProducaoExterna = 0.20;
-    public const PRODUCAO_INTERNA = 1;
-    public const PRODUCAO_EXTERNA = 2;
     public function __construct(
-        private int $tipoProducao = self::PRODUCAO_EXTERNA
+        private TipoProducao $tipoProducao = TipoProducao::PRODUCAO_EXTERNA,
     ) {
     }
 
     public function calcula(float $base): float
     {
+        if ($base <= 0) {
+            return 0;
+        }
         if ($this->producaoInterna()) {
             if ($base > $this->baseMaxima) {
                 return $this->baseMaxima * $this->aliquotaProducaoInterna;
@@ -56,11 +57,11 @@ class INSS
 
     private function producaoExterna(): bool
     {
-        return $this->tipoProducao === self::PRODUCAO_EXTERNA;
+        return $this->tipoProducao === TipoProducao::PRODUCAO_EXTERNA;
     }
 
     private function producaoInterna(): bool
     {
-        return $this->tipoProducao === self::PRODUCAO_INTERNA;
+        return $this->tipoProducao === TipoProducao::PRODUCAO_INTERNA;
     }
 }

--- a/src/Service/TipoProducao.php
+++ b/src/Service/TipoProducao.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * @copyright Copyright (c) 2023, Vitor Mattos <vitor@php.rio>
+ *
+ * @author Vitor Mattos <vitor@php.rio>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+declare(strict_types=1);
+
+namespace ProducaoCooperativista\Service;
+
+enum TipoProducao: int
+{
+    case PRODUCAO_INTERNA = 1;
+    case PRODUCAO_EXTERNA = 2;
+}

--- a/tests/php/Service/INSSTest.php
+++ b/tests/php/Service/INSSTest.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * @copyright Copyright (c) 2023, Vitor Mattos <vitor@php.rio>
+ *
+ * @author Vitor Mattos <vitor@php.rio>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+declare(strict_types=1);
+
+use ProducaoCooperativista\Service\INSS;
+use ProducaoCooperativista\Service\TipoProducao;
+use Tests\Php\TestCase;
+
+final class INSSTest extends TestCase
+{
+    /**
+     * @dataProvider providerCalcula
+     */
+    public function testCalcula(float $base, TipoProducao $tipoProducao, float $expected): void
+    {
+        $INSS = new INSS($tipoProducao);
+        $actual = $INSS->calcula($base);
+        /**
+         * @todo remover o round
+         */
+        $this->assertEquals($expected, round($actual, 2));
+    }
+
+    public static function providerCalcula(): array
+    {
+        return [
+            [-100, TipoProducao::PRODUCAO_EXTERNA, 0],
+            [-50, TipoProducao::PRODUCAO_EXTERNA, 0],
+            [0, TipoProducao::PRODUCAO_EXTERNA, 0],
+            [1000, TipoProducao::PRODUCAO_EXTERNA, 200],
+            [7000, TipoProducao::PRODUCAO_EXTERNA, 1400],
+            [7087.16, TipoProducao::PRODUCAO_EXTERNA, 1417.43],
+            [7087.17, TipoProducao::PRODUCAO_EXTERNA, 1417.43],
+            // Arredondamentos de centavos da base máxima começa aqui
+            [7087.18, TipoProducao::PRODUCAO_EXTERNA, 1417.44],
+            [7087.19, TipoProducao::PRODUCAO_EXTERNA, 1417.44],
+            [7088, TipoProducao::PRODUCAO_EXTERNA, 1417.44],
+            [8000, TipoProducao::PRODUCAO_EXTERNA, 1417.44],
+            [100000, TipoProducao::PRODUCAO_EXTERNA, 1417.44],
+        ];
+    }
+}


### PR DESCRIPTION
Apenas acrescentei testes para produção externa pois não trabalhamos com produção interna.

Converti as constantes para enum para evitar problemas de passar algo que não sejam valores aceitáveis no construtor.