### PR TITLE
Fix health insurance bill selection

### DIFF
--- a/src/Service/Akaunting/Document/ProducaoCooperativista.php
+++ b/src/Service/Akaunting/Document/ProducaoCooperativista.php
@@ -108,30 +108,83 @@ class ProducaoCooperativista extends ADocument
     public function updateHealthInsurance(): self
     {
         $select = $this->entityManager->getConnection()->createQueryBuilder();
-        $select->select("JSON_UNQUOTE(JSON_EXTRACT(i.metadata, '$.notes')) as notes")
+        $select->select('i.metadata')
             ->from('invoices', 'i')
             ->where("i.type = 'bill'")
             ->andWhere($select->expr()->eq('i.category_id', $select->createNamedParameter((int) getenv('AKAUNTING_PLANO_DE_SAUDE_CATEGORY_ID'), ParameterType::INTEGER)))
-            ->andWhere($select->expr()->gte('i.transaction_of_month', $select->createNamedParameter($this->dates->getInicioProximoMes()->format('Y-m'))));
-        $text = $select->executeQuery()->fetchOne();
-        if (empty($text)) {
+            ->andWhere($select->expr()->eq('i.transaction_of_month', $select->createNamedParameter($this->dates->getInicioProximoMes()->format('Y-m'))))
+            ->orderBy('i.id', 'DESC');
+        $rows = $select->executeQuery()->fetchAllAssociative();
+        if (empty($rows)) {
             return $this;
         }
 
-        $explodedText = explode("\n", $text);
-        $pattern = '/^Cooperado: .*CPF: (?<CPF>\d+)[,;]? Valor: (R\$ ?)?(?<value>.*)$/i';
-        foreach ($explodedText as $row) {
-            if (!preg_match($pattern, $row, $matches)) {
+        foreach ($rows as $row) {
+            $metadata = $this->decodeInvoiceMetadata($row['metadata'] ?? null);
+            $notes = $metadata['notes'] ?? null;
+            if (!is_string($notes) || $notes === '') {
                 continue;
             }
-            if ($matches['CPF'] === $this->getCooperado()->getTaxNumber()) {
-                $value = str_replace('.', '', $matches['value']);
-                $value = str_replace(',', '.', $value);
-                $value = (float) $value;
-                $this->values->setHealthInsurance($value);
+
+            $healthInsurance = null;
+            foreach ($this->extractHealthInsuranceMatches($notes) as $match) {
+                if ($match['CPF'] !== $this->getCooperado()->getTaxNumber()) {
+                    continue;
+                }
+                $healthInsurance = $match['value'];
+            }
+
+            if ($healthInsurance !== null) {
+                $this->values->setHealthInsurance($healthInsurance);
+                return $this;
             }
         }
+
         return $this;
+    }
+
+    private function decodeInvoiceMetadata(mixed $metadata): array
+    {
+        if (is_array($metadata)) {
+            return $metadata;
+        }
+        if (!is_string($metadata) || $metadata === '') {
+            return [];
+        }
+
+        $decoded = json_decode($metadata, true);
+        if (!is_array($decoded)) {
+            return [];
+        }
+        return $decoded;
+    }
+
+    /**
+     * @return array<int, array{CPF: string, value: float}>
+     */
+    private function extractHealthInsuranceMatches(string $text): array
+    {
+        $matches = [];
+        $pattern = '/^Cooperado: .*CPF: (?<CPF>\d+)[,;]? Valor: (R\$ ?)?(?<value>.*)$/i';
+        foreach (explode("\n", $text) as $row) {
+            if (!preg_match($pattern, $row, $match)) {
+                continue;
+            }
+            $matches[] = [
+                'CPF' => $match['CPF'],
+                'value' => $this->parseMoneyValue($match['value']),
+            ];
+        }
+        return $matches;
+    }
+
+    private function parseMoneyValue(string $value): float
+    {
+        $value = trim($value);
+        $value = preg_replace('/[^0-9,.-]/', '', $value) ?? '';
+        $value = str_replace('.', '', $value);
+        $value = str_replace(',', '.', $value);
+        return (float) $value;
     }
 
     protected function getDocumentNumber(): string

--- a/tests/php/Service/Akaunting/Document/ProducaoCooperativistaTest.php
+++ b/tests/php/Service/Akaunting/Document/ProducaoCooperativistaTest.php
@@ -1,0 +1,177 @@
+<?php
+
+/**
+ * @copyright Copyright (c) 2026, LibreCode contributors
+ *
+ * @author LibreCode contributors
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+declare(strict_types=1);
+
+namespace App\Tests\Service\Akaunting\Document;
+
+use App\Entity\Producao\Invoice;
+use App\Helper\Dates;
+use App\Provider\Akaunting\Request;
+use App\Service\Akaunting\Document\ProducaoCooperativista;
+use App\Service\Akaunting\Source\Documents;
+use App\Service\Cooperado;
+use DateTime;
+use Doctrine\ORM\EntityManagerInterface;
+use NumberFormatter;
+use Tests\Php\TestCase;
+
+final class ProducaoCooperativistaTest extends TestCase
+{
+    private const COOPERADO_NOME = 'Cooperado Exemplo';
+    private const COOPERADO_CPF = '00011122233';
+    private const VALOR_BENEFICIO_SECUNDARIO = 12.34;
+    private const VALOR_BENEFICIO_PRINCIPAL = 56.78;
+
+    private EntityManagerInterface $entityManager;
+    private Dates $dates;
+    private Documents $documents;
+    private Request $request;
+    private NumberFormatter $numberFormatter;
+
+    protected function setUp(): void
+    {
+        static::bootKernel();
+
+        $container = static::getContainer();
+        $this->entityManager = $container->get(EntityManagerInterface::class);
+        $this->dates = $container->get(Dates::class);
+        $this->documents = $container->get(Documents::class);
+        $this->request = $container->get(Request::class);
+        $this->numberFormatter = new NumberFormatter((string) getenv('LOCALE'), NumberFormatter::CURRENCY);
+
+        $this->entityManager->getConnection()->executeStatement('DELETE FROM invoices');
+        $this->entityManager->clear();
+
+        $this->dates->setInicio(new DateTime('2026-04-01 00:00:00'));
+    }
+
+    public function testUpdateHealthInsuranceUsesMostRecentMatchingBillInCategory(): void
+    {
+        $this->persistBill(
+            id: 1001,
+            amount: self::VALOR_BENEFICIO_SECUNDARIO,
+            notes: 'Cooperado: ' . self::COOPERADO_NOME . ', CPF: ' . self::COOPERADO_CPF . ', Valor: R$ 12,34',
+            itemDescription: 'Lançamento genérico 1001',
+            contactName: 'Fornecedor Exemplo A'
+        );
+        $this->persistBill(
+            id: 1002,
+            amount: self::VALOR_BENEFICIO_PRINCIPAL,
+            notes: 'Cooperado: ' . self::COOPERADO_NOME . ', CPF: ' . self::COOPERADO_CPF . ', Valor: R$ 56,78',
+            itemDescription: 'Lançamento genérico 1002',
+            contactName: 'Fornecedor Exemplo B'
+        );
+
+        $document = $this->createDocumentForCooperado(self::COOPERADO_NOME, self::COOPERADO_CPF);
+        $document->updateHealthInsurance();
+
+        $this->assertSame(56.78, round($document->getValues()->getHealthInsurance(), 2));
+    }
+
+    public function testUpdateHealthInsuranceSkipsMostRecentBillWhenCpfDoesNotMatch(): void
+    {
+        $this->persistBill(
+            id: 1003,
+            amount: self::VALOR_BENEFICIO_SECUNDARIO,
+            notes: 'Cooperado: ' . self::COOPERADO_NOME . ', CPF: ' . self::COOPERADO_CPF . ', Valor: R$ 12,34',
+            itemDescription: 'Lançamento genérico 1003',
+            contactName: 'Fornecedor Exemplo B'
+        );
+        $this->persistBill(
+            id: 1004,
+            amount: self::VALOR_BENEFICIO_PRINCIPAL,
+            notes: 'Cooperado: Outro Cooperado, CPF: 99988877766, Valor: R$ 56,78',
+            itemDescription: 'Lançamento genérico 1004',
+            contactName: 'Fornecedor Exemplo C'
+        );
+
+        $document = $this->createDocumentForCooperado(self::COOPERADO_NOME, self::COOPERADO_CPF);
+        $document->updateHealthInsurance();
+
+        $this->assertSame(12.34, round($document->getValues()->getHealthInsurance(), 2));
+    }
+
+    private function createDocumentForCooperado(string $name, string $taxNumber): ProducaoCooperativista
+    {
+        $cooperado = new Cooperado(
+            entityManager: $this->entityManager,
+            dates: $this->dates,
+            numberFormatter: $this->numberFormatter,
+            documents: $this->documents,
+            request: $this->request,
+            anoFiscal: 2026,
+            mes: 4,
+        );
+        $cooperado
+            ->setName($name)
+            ->setTaxNumber($taxNumber)
+            ->setAkauntingContactId(172)
+            ->setDependentes(0)
+            ->setWeight(1);
+
+        return $cooperado->getProducaoCooperativista();
+    }
+
+    private function persistBill(int $id, float $amount, string $notes, string $itemDescription, string $contactName): void
+    {
+        $invoice = new Invoice();
+        $invoice->fromArray([
+            'id' => $id,
+            'type' => 'bill',
+            'issued_at' => '2026-05-04 10:41:39',
+            'due_at' => '2026-05-04 10:41:39',
+            'transaction_of_month' => '2026-05',
+            'amount' => $amount,
+            'discount_percentage' => null,
+            'currency_code' => 'BRL',
+            'document_number' => sprintf('BILL-%d', $id),
+            'nfse' => null,
+            'tax_number' => '00000000000000',
+            'customer_reference' => null,
+            'contact_id' => $id,
+            'contact_reference' => null,
+            'contact_name' => $contactName,
+            'contact_type' => 'vendor',
+            'category_id' => (int) getenv('AKAUNTING_PLANO_DE_SAUDE_CATEGORY_ID'),
+            'category_name' => 'Cooperado > Produção > Plano de saúde',
+            'category_type' => 'expense',
+            'archive' => 0,
+            'metadata' => [
+                'status' => 'paid',
+                'notes' => $notes,
+                'items' => [
+                    'data' => [[
+                        'name' => 'Serviço',
+                        'description' => $itemDescription,
+                        'price' => $amount,
+                    ]],
+                ],
+            ],
+        ]);
+
+        $this->entityManager->persist($invoice);
+        $this->entityManager->flush();
+    }
+}


### PR DESCRIPTION
## Summary
- select the latest bill ID in the configured health insurance category for the exact competence month
- only use a bill when the cooperado CPF is present in the imported notes, avoiding mutable item or description names
- add regression coverage for latest-match selection and CPF fallback behavior

## Validation
- `docker compose exec php sh -lc 'cd /app && /app/vendor-bin/unit/vendor/bin/phpunit -c tests/php/phpunit.xml --filter ProducaoCooperativistaTest --testdox --no-coverage --fail-on-warning --fail-on-risky'`
- `docker compose exec php sh -lc 'cd /app && /app/vendor-bin/unit/vendor/bin/phpunit -c tests/php/phpunit.xml --no-coverage --fail-on-warning --fail-on-risky'`
- smoke check against local report data returned `1592.65` for `2026-04`
