### PR TITLE
Integrate production weights with Profile Fields

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -102,6 +102,17 @@ KIMAI_API_BASE_URL=https://kimai.yourdomain.tld/api
 # Vá no seu perfil, editar, API, defina uma senha de API e use ela aqui
 KIMAI_API_TOKEN=api-token
 
+# URL base do Nextcloud que possui o app Profile Fields instalado
+PROFILE_FIELDS_API_BASE_URL=https://nextcloud.yourdomain.tld
+# Usuário com acesso administrativo à API OCS do Profile Fields
+PROFILE_FIELDS_AUTH_USER=
+# Token/senha de app do usuário acima
+PROFILE_FIELDS_AUTH_TOKEN=
+# Chave do campo no Profile Fields que guarda o peso do cooperado
+PROFILE_FIELDS_WEIGHT_FIELD_KEY=weight
+# Chave do campo no Profile Fields que guarda o CPF/CNPJ do cooperado
+PROFILE_FIELDS_TAX_NUMBER_FIELD_KEY=tax_number
+
 # Nome da prefeitura a importar dados no mês
 PREFEITURA=niteroi
 PREFEITURA_LOGIN=

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Calcular o bruto da produção cooperativista por cooperado com base em dados co
 | ---------------------------------- | --------------------------------------------------------------------------------------------------------- |
 | [Kimai](https://www.kimai.org)     | Registro de horas trabalhadas por projeto, emissão de relatório de horas trabalhadas para clientes        |
 | [Akaunting](https://akaunting.com) | Gestão financeira                                                                                         |
+| [Nextcloud + Profile Fields](https://github.com/LibreCodeCoop/profile_fields/) | Diretório interno dos cooperados com os campos customizados `weight` e `tax_number` usados na produção |
 | Site da prefeitura                 | Emissão de NFSe. Hoje o sistema dá suporte oficial apenas as prefeituras dos municípios do Rio e Niterói. |
 
 ## Ambiente de desenvolvimento
@@ -53,6 +54,9 @@ E peça o `.env` de prod ao time de infraestrutura. Irão te passar sem as crede
 * Emissão de notas fiscais
   * Definir a descrição da nota fiscal com campos separados por `:` (dois pontos)
   * Quando for NFSe para mais de um setor de um mesmo CNPJ, acrescentar o campo `setor: <setor>`
+* Nextcloud + Profile Fields
+  * Criar no app `profile_fields` os campos `weight` e `tax_number`.
+  * Preencher estes campos para cada cooperado; eles passam a ser a fonte oficial do peso e do CPF/CNPJ usados no cálculo.
 * Akaunting
   * Dados de clientes
     * Definir número de identificação fiscal (cpf/cnpj) para todo fornecedor/cliente. Quando houver nota emitida para mais de um setor de um mesmo CNPJ e figurarem diferentes contas na LibreCode (conta = contrato), concatenar da seguinte forma: `<cpf/CNPJ>|<setor>`

--- a/src/Command/MakeProducaoCommand.php
+++ b/src/Command/MakeProducaoCommand.php
@@ -26,7 +26,6 @@ declare(strict_types=1);
 
 namespace App\Command;
 
-use App\Service\Kimai\Source\Users;
 use App\Service\Movimentacao;
 use DateTime;
 use App\Service\ProducaoCooperativista;
@@ -45,7 +44,6 @@ class MakeProducaoCommand extends AbstractBaseCommand
     public function __construct(
         private ProducaoCooperativista $producaoCooperativista,
         private Movimentacao $movimentacao,
-        private Users $users,
     ) {
         parent::__construct();
     }
@@ -94,12 +92,6 @@ class MakeProducaoCommand extends AbstractBaseCommand
                 'Atualiza a produção cooperativista no Akaunting'
             )
             ->addOption(
-                'pesos',
-                null,
-                InputOption::VALUE_REQUIRED,
-                'Pesos finais para cálculo da produção'
-            )
-            ->addOption(
                 'ods',
                 null,
                 InputOption::VALUE_NONE,
@@ -128,8 +120,6 @@ class MakeProducaoCommand extends AbstractBaseCommand
         $this->producaoCooperativista->dates->setInicio($inicio);
         $this->producaoCooperativista->dates->setDiasUteis($diasUteis);
         $this->movimentacao->setPercentualMaximo($percentualMaximo);
-        $pesos = json_decode((string) $input->getOption('pesos'), true) ?? [];
-        $this->users->updatePesos($pesos);
 
         try {
             $this->producaoCooperativista->getProducaoCooperativista();

--- a/src/Controller/Acoes.php
+++ b/src/Controller/Acoes.php
@@ -141,7 +141,6 @@ class Acoes extends AbstractController
             '--baixar-dados' => $this->request->query->getString('baixar_dados', '0'),
             '--atualiza-producao' => $this->request->query->getBoolean('atualiza_producao'),
             '--database' => true,
-            '--pesos' => $this->request->query->getString('pesos'),
         ]);
         $output = new BufferedOutput();
         $exitCode = $application->run($input, $output);

--- a/src/Service/Kimai/Source/Users.php
+++ b/src/Service/Kimai/Source/Users.php
@@ -28,9 +28,9 @@ namespace App\Service\Kimai\Source;
 
 use App\Entity\Producao\User;
 use Doctrine\DBAL\ArrayParameterType;
-use Doctrine\DBAL\ParameterType;
 use InvalidArgumentException;
 use App\Provider\Kimai;
+use App\Service\Nextcloud\ProfileFieldsClient;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\ManagerRegistry;
 use Psr\Log\LoggerInterface;
@@ -51,7 +51,8 @@ class Users
     public function __construct(
         ManagerRegistry $managerRegistry,
         private EntityManagerInterface $entityManager,
-        private LoggerInterface $logger
+        private LoggerInterface $logger,
+        private ProfileFieldsClient $profileFieldsClient,
     ) {
         $this->entityManagerAkaunting = $managerRegistry->getManager('akaunting');
     }
@@ -98,6 +99,7 @@ class Users
     public function fromArray(array $array): User
     {
         $array = $this->updateFromUserPreferences($array);
+        $array = $this->profileFieldsClient->enrichUser($array);
         $array = $this->updateWithAkauntingData($array);
         $array = $this->convertFields($array);
         $entity = $this->entityManager->find(User::class, $array['id']);
@@ -163,18 +165,6 @@ class Users
             $item['akaunting_contact_id'] = $row['id'];
         }
         return $item;
-    }
-
-    public function updatePesos(array $pesos): self
-    {
-        $update = $this->entityManager->getConnection()->createQueryBuilder();
-        foreach ($pesos as $cooperado) {
-            $update->update('users')
-                ->set('peso', $update->createNamedParameter($cooperado['weight']))
-                ->where($update->expr()->eq('tax_number', $update->createNamedParameter($cooperado['tax_number'], ParameterType::STRING)))
-                ->executeStatement();
-        }
-        return $this;
     }
 
     public function saveList(): self

--- a/src/Service/Nextcloud/ProfileFieldsClient.php
+++ b/src/Service/Nextcloud/ProfileFieldsClient.php
@@ -1,0 +1,267 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Nextcloud;
+
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+class ProfileFieldsClient
+{
+    /** @var array<int, string>|null */
+    private ?array $definitionFieldKeysById = null;
+
+    /** @var array<string, array<string, mixed>> */
+    private array $fieldsByUserUid = [];
+
+    /** @var array<string, array<string, mixed>> */
+    private array $fieldsByTaxNumber = [];
+
+    public function __construct(
+        private HttpClientInterface $httpClient,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    public function isConfigured(): bool
+    {
+        return $this->getBaseUrl() !== ''
+            && $this->getAuthUser() !== ''
+            && $this->getAuthToken() !== '';
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getFieldsForUser(string $userUid): array
+    {
+        if (!$this->isConfigured() || $userUid === '') {
+            return [];
+        }
+
+        if (isset($this->fieldsByUserUid[$userUid])) {
+            return $this->fieldsByUserUid[$userUid];
+        }
+
+        $fields = [];
+        foreach ($this->requestOcs(
+            '/ocs/v2.php/apps/profile_fields/api/v1/users/' . rawurlencode($userUid) . '/values',
+            allowNotFound: true,
+        ) as $row) {
+            if (!is_array($row)) {
+                continue;
+            }
+
+            $definitionId = (int) ($row['field_definition_id'] ?? 0);
+            if ($definitionId <= 0) {
+                continue;
+            }
+
+            $fieldKey = $this->getDefinitionFieldKey($definitionId);
+            if ($fieldKey === null) {
+                continue;
+            }
+
+            $fields[$fieldKey] = $this->normalizeValue($row['value'] ?? null);
+        }
+
+        $this->fieldsByUserUid[$userUid] = $fields;
+
+        return $fields;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getFieldsForTaxNumber(string $taxNumber): array
+    {
+        $taxNumber = trim($taxNumber);
+        if (!$this->isConfigured() || $taxNumber === '') {
+            return [];
+        }
+
+        if (isset($this->fieldsByTaxNumber[$taxNumber])) {
+            return $this->fieldsByTaxNumber[$taxNumber];
+        }
+
+        $lookup = $this->requestOcs(
+            '/ocs/v2.php/apps/profile_fields/api/v1/users/lookup',
+            method: 'POST',
+            options: [
+                'json' => [
+                    'fieldKey' => $this->getTaxNumberFieldKey(),
+                    'fieldValue' => $taxNumber,
+                ],
+            ],
+            allowNotFound: true,
+        );
+
+        $fields = [];
+        $lookupFields = $lookup['fields'] ?? null;
+        if (is_array($lookupFields)) {
+            foreach ($lookupFields as $fieldKey => $field) {
+                if (!is_string($fieldKey) || !is_array($field)) {
+                    continue;
+                }
+
+                $fields[$fieldKey] = $this->normalizeValue($field['value'] ?? null);
+            }
+        }
+
+        $this->fieldsByTaxNumber[$taxNumber] = $fields;
+
+        return $fields;
+    }
+
+    /**
+     * @param array<string, mixed> $user
+     * @return array<string, mixed>
+     */
+    public function enrichUser(array $user): array
+    {
+        $taxNumber = trim((string) ($user['tax_number'] ?? ''));
+        if ($taxNumber === '') {
+            return $user;
+        }
+
+        $fields = $this->getFieldsForTaxNumber($taxNumber);
+        if ($fields === []) {
+            return $user;
+        }
+
+        $taxNumberFieldKey = $this->getTaxNumberFieldKey();
+        $taxNumber = $fields[$taxNumberFieldKey] ?? null;
+        if (is_scalar($taxNumber) && trim((string) $taxNumber) !== '') {
+            $user['tax_number'] = trim((string) $taxNumber);
+        }
+
+        $weightFieldKey = $this->getWeightFieldKey();
+        $weight = $fields[$weightFieldKey] ?? null;
+        if (is_scalar($weight) && is_numeric((string) $weight)) {
+            $user['peso'] = (float) $weight;
+        }
+
+        return $user;
+    }
+
+    private function getDefinitionFieldKey(int $definitionId): ?string
+    {
+        if ($this->definitionFieldKeysById === null) {
+            $this->definitionFieldKeysById = [];
+            foreach ($this->requestOcs('/ocs/v2.php/apps/profile_fields/api/v1/definitions') as $definition) {
+                if (!is_array($definition)) {
+                    continue;
+                }
+
+                $id = (int) ($definition['id'] ?? 0);
+                $fieldKey = $definition['field_key'] ?? $definition['fieldKey'] ?? null;
+                if ($id <= 0 || !is_string($fieldKey) || $fieldKey === '') {
+                    continue;
+                }
+
+                $this->definitionFieldKeysById[$id] = $fieldKey;
+            }
+        }
+
+        return $this->definitionFieldKeysById[$definitionId] ?? null;
+    }
+
+    /**
+     * @return array<int|string, mixed>
+     */
+    private function requestOcs(
+        string $path,
+        string $method = 'GET',
+        array $options = [],
+        bool $allowNotFound = false,
+    ): array
+    {
+        if (!$this->isConfigured()) {
+            return [];
+        }
+
+        $url = rtrim($this->getBaseUrl(), '/') . $path;
+        $options = array_replace_recursive([
+            'auth_basic' => [$this->getAuthUser(), $this->getAuthToken()],
+            'headers' => [
+                'Accept' => 'application/json',
+                'OCS-APIRequest' => 'true',
+            ],
+        ], $options);
+
+        $response = $this->httpClient->request($method, $url, $options);
+
+        $statusCode = $response->getStatusCode();
+        $payload = $response->toArray(false);
+
+        if ($statusCode === 404 && $allowNotFound) {
+            return [];
+        }
+
+        if ($statusCode < 200 || $statusCode >= 300) {
+            throw new RuntimeException(sprintf(
+                'Falha ao consultar a API Profile Fields (%d): %s',
+                $statusCode,
+                $this->getErrorMessage($payload),
+            ));
+        }
+
+        $metaStatusCode = (int) ($payload['ocs']['meta']['statuscode'] ?? 100);
+        if ($metaStatusCode >= 400) {
+            throw new RuntimeException(sprintf(
+                'Falha ao consultar a API Profile Fields (%d): %s',
+                $metaStatusCode,
+                $this->getErrorMessage($payload),
+            ));
+        }
+
+        $data = $payload['ocs']['data'] ?? [];
+        return is_array($data) ? $data : [];
+    }
+
+    private function normalizeValue(mixed $value): mixed
+    {
+        if (is_array($value) && array_key_exists('value', $value)) {
+            return $this->normalizeValue($value['value']);
+        }
+
+        return $value;
+    }
+
+    private function getErrorMessage(array $payload): string
+    {
+        $message = $payload['ocs']['data']['message']
+            ?? $payload['ocs']['meta']['message']
+            ?? $payload['message']
+            ?? 'Resposta inesperada';
+
+        return is_string($message) && $message !== '' ? $message : 'Resposta inesperada';
+    }
+
+    private function getBaseUrl(): string
+    {
+        return trim((string) getenv('PROFILE_FIELDS_API_BASE_URL'));
+    }
+
+    private function getAuthUser(): string
+    {
+        return trim((string) getenv('PROFILE_FIELDS_AUTH_USER'));
+    }
+
+    private function getAuthToken(): string
+    {
+        return trim((string) getenv('PROFILE_FIELDS_AUTH_TOKEN'));
+    }
+
+    private function getTaxNumberFieldKey(): string
+    {
+        return trim((string) getenv('PROFILE_FIELDS_TAX_NUMBER_FIELD_KEY')) ?: 'tax_number';
+    }
+
+    private function getWeightFieldKey(): string
+    {
+        return trim((string) getenv('PROFILE_FIELDS_WEIGHT_FIELD_KEY')) ?: 'weight';
+    }
+}

--- a/src/Service/Nextcloud/ProfileFieldsClient.php
+++ b/src/Service/Nextcloud/ProfileFieldsClient.php
@@ -176,8 +176,7 @@ class ProfileFieldsClient
         string $method = 'GET',
         array $options = [],
         bool $allowNotFound = false,
-    ): array
-    {
+    ): array {
         if (!$this->isConfigured()) {
             return [];
         }

--- a/templates/acoes/make_producao.html.twig
+++ b/templates/acoes/make_producao.html.twig
@@ -61,10 +61,6 @@
             <input type="radio" id="atualiza_producao_nao" name="atualiza_producao" value="0"{% if atualiza_producao == 0 %} checked{% endif %} /><label for="atualiza_producao_nao">Não</label>
             <input type="radio" id="atualiza_producao_sim" name="atualiza_producao" value="1"{% if atualiza_producao == 1 %} checked{% endif %} /><label for="atualiza_producao_sim">Sim</label>
         </fieldset>
-        <fieldset>
-            <legend>Tabela de pesos</legend>
-            <textarea name="pesos"></textarea>
-        </fieldset>
         <br />
         <input type="submit" value="Executa" id="submit" />
     </form>

--- a/tests/php/Service/Nextcloud/ProfileFieldsClientTest.php
+++ b/tests/php/Service/Nextcloud/ProfileFieldsClientTest.php
@@ -1,0 +1,211 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Service\Nextcloud;
+
+use App\Service\Nextcloud\ProfileFieldsClient;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+final class ProfileFieldsClientTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        putenv('PROFILE_FIELDS_API_BASE_URL');
+        putenv('PROFILE_FIELDS_AUTH_USER');
+        putenv('PROFILE_FIELDS_AUTH_TOKEN');
+        putenv('PROFILE_FIELDS_TAX_NUMBER_FIELD_KEY');
+        putenv('PROFILE_FIELDS_WEIGHT_FIELD_KEY');
+    }
+
+    public function testGetFieldsForTaxNumberMapsValuesByFieldKey(): void
+    {
+        putenv('PROFILE_FIELDS_API_BASE_URL=https://nextcloud.example.com');
+        putenv('PROFILE_FIELDS_AUTH_USER=api-user');
+        putenv('PROFILE_FIELDS_AUTH_TOKEN=api-token');
+
+        $calls = [];
+        $httpClient = new MockHttpClient(function (string $method, string $url, array $options) use (&$calls): MockResponse {
+            $calls[] = compact('method', 'url', 'options');
+
+            if (str_ends_with($url, '/users/lookup')) {
+                self::assertSame('POST', $method);
+                self::assertLookupPayload($options, [
+                    'fieldKey' => 'tax_number',
+                    'fieldValue' => '11122233344',
+                ]);
+
+                return new MockResponse((string) json_encode([
+                    'ocs' => [
+                        'meta' => [
+                            'status' => 'ok',
+                            'statuscode' => 100,
+                        ],
+                        'data' => [
+                            'user_uid' => 'pessoa02',
+                            'lookup_field_key' => 'tax_number',
+                            'fields' => [
+                                'tax_number' => [
+                                    'definition' => [
+                                        'field_key' => 'tax_number',
+                                    ],
+                                    'value' => [
+                                        'field_definition_id' => 10,
+                                        'value' => [
+                                            'value' => '11122233344',
+                                        ],
+                                    ],
+                                ],
+                                'weight' => [
+                                    'definition' => [
+                                        'field_key' => 'weight',
+                                    ],
+                                    'value' => [
+                                        'field_definition_id' => 11,
+                                        'value' => [
+                                            'value' => '2.5',
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ]));
+            }
+
+            return new MockResponse('not found', ['http_code' => 404]);
+        });
+
+        $client = new ProfileFieldsClient($httpClient, new NullLogger());
+        $fields = $client->getFieldsForTaxNumber('11122233344');
+
+        self::assertSame([
+            'tax_number' => '11122233344',
+            'weight' => '2.5',
+        ], $fields);
+        self::assertCount(1, $calls);
+    }
+
+    public function testGetFieldsForTaxNumberReturnsEmptyArrayWhenIntegrationIsNotConfigured(): void
+    {
+        $httpClient = new MockHttpClient(function (): MockResponse {
+            self::fail('The Profile Fields API should not be called when the integration is not configured.');
+        });
+
+        $client = new ProfileFieldsClient($httpClient, new NullLogger());
+
+        self::assertSame([], $client->getFieldsForTaxNumber('11122233344'));
+    }
+
+    public function testEnrichUserUsesTaxNumberLookupAndMapsPesoFromProfileFields(): void
+    {
+        putenv('PROFILE_FIELDS_API_BASE_URL=https://nextcloud.example.com');
+        putenv('PROFILE_FIELDS_AUTH_USER=api-user');
+        putenv('PROFILE_FIELDS_AUTH_TOKEN=api-token');
+
+        $httpClient = new MockHttpClient(function (string $method, string $url, array $options): MockResponse {
+            if (str_ends_with($url, '/users/lookup')) {
+                self::assertSame('POST', $method);
+                self::assertLookupPayload($options, [
+                    'fieldKey' => 'tax_number',
+                    'fieldValue' => '11122233344',
+                ]);
+
+                return new MockResponse((string) json_encode([
+                    'ocs' => [
+                        'meta' => [
+                            'status' => 'ok',
+                            'statuscode' => 100,
+                        ],
+                        'data' => [
+                            'user_uid' => 'pessoa02',
+                            'lookup_field_key' => 'tax_number',
+                            'fields' => [
+                                'tax_number' => [
+                                    'definition' => [
+                                        'field_key' => 'tax_number',
+                                    ],
+                                    'value' => [
+                                        'field_definition_id' => 10,
+                                        'value' => [
+                                            'value' => '11122233344',
+                                        ],
+                                    ],
+                                ],
+                                'weight' => [
+                                    'definition' => [
+                                        'field_key' => 'weight',
+                                    ],
+                                    'value' => [
+                                        'field_definition_id' => 11,
+                                        'value' => [
+                                            'value' => '1.75',
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ]));
+            }
+
+            return new MockResponse('not found', ['http_code' => 404]);
+        });
+
+        $client = new ProfileFieldsClient($httpClient, new NullLogger());
+
+        self::assertSame([
+            'id' => 2,
+            'username' => 'vitor@librecode.coop',
+            'kimai_username' => 'vitor@librecode.coop',
+            'tax_number' => '11122233344',
+            'peso' => 1.75,
+        ], $client->enrichUser([
+            'id' => 2,
+            'username' => 'vitor@librecode.coop',
+            'kimai_username' => 'vitor@librecode.coop',
+            'tax_number' => '11122233344',
+        ]));
+    }
+
+    public function testEnrichUserDoesNotFallbackToKimaiUsernameWhenTaxNumberIsMissing(): void
+    {
+        putenv('PROFILE_FIELDS_API_BASE_URL=https://nextcloud.example.com');
+        putenv('PROFILE_FIELDS_AUTH_USER=api-user');
+        putenv('PROFILE_FIELDS_AUTH_TOKEN=api-token');
+
+        $httpClient = new MockHttpClient(function (): MockResponse {
+            self::fail('Profile Fields lookup must use tax_number and should not fallback to kimai_username when it is missing.');
+        });
+
+        $client = new ProfileFieldsClient($httpClient, new NullLogger());
+
+        self::assertSame([
+            'id' => 2,
+            'username' => 'pessoa02',
+            'kimai_username' => 'pessoa02',
+        ], $client->enrichUser([
+            'id' => 2,
+            'username' => 'pessoa02',
+            'kimai_username' => 'pessoa02',
+        ]));
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     * @param array<string, string> $expectedPayload
+     */
+    private static function assertLookupPayload(array $options, array $expectedPayload): void
+    {
+        $payload = $options['json'] ?? $options['body'] ?? null;
+
+        if (is_string($payload)) {
+            $payload = json_decode($payload, true, 512, JSON_THROW_ON_ERROR);
+        }
+
+        self::assertSame($expectedPayload, $payload);
+    }
+}


### PR DESCRIPTION
## Summary
- replace the manual production weight JSON/textarea flow with a Nextcloud Profile Fields integration
- sync `tax_number` and `weight` during Kimai user import and stop depending on matching the Nextcloud `userUid`
- query the Profile Fields lookup endpoint by `tax_number`, which is the correct lookup key for the production flow
- update the command/UI/docs to remove the manual weight input and document the new environment variables
- add regression coverage for the Profile Fields client

## Validation
- `docker compose exec php sh -lc 'cd /app && ./vendor-bin/unit/vendor/bin/phpunit -c tests/php/phpunit.xml --filter ProfileFieldsClientTest --no-coverage --fail-on-warning --fail-on-risky'`
- `docker compose exec php sh -lc 'cd /app && ./vendor-bin/unit/vendor/bin/phpunit -c tests/php/phpunit.xml --filter "(MakeProducaoCommandTest|ProfileFieldsClientTest)" --no-coverage --fail-on-warning --fail-on-risky'`
- live validation against current-month active Kimai users using Profile Fields lookup by `tax_number`