### PR TITLE
Fix liquid discount aggregation for duplicate bills

### DIFF
--- a/src/Service/Akaunting/Document/ProducaoCooperativista.php
+++ b/src/Service/Akaunting/Document/ProducaoCooperativista.php
@@ -147,7 +147,7 @@ class ProducaoCooperativista extends ADocument
         $selectedDiscounts = [];
         foreach ($rows as $row) {
             $categoryId = (int) ($row['category_id'] ?? 0);
-            if ($categoryId <= 0 || isset($selectedDiscounts[$categoryId])) {
+            if ($categoryId <= 0) {
                 continue;
             }
 
@@ -162,7 +162,7 @@ class ProducaoCooperativista extends ADocument
                     continue;
                 }
 
-                $selectedDiscounts[$categoryId] = [
+                $selectedDiscounts[] = [
                     'category_id' => $categoryId,
                     'category_name' => (string) ($row['category_name'] ?? ''),
                     'amount' => $match['value'],
@@ -177,7 +177,7 @@ class ProducaoCooperativista extends ADocument
             return $this;
         }
 
-        $this->liquidDiscounts = array_values($selectedDiscounts);
+        $this->liquidDiscounts = $selectedDiscounts;
         $totalLiquidDiscount = array_reduce(
             $this->liquidDiscounts,
             fn (float $carry, array $discount): float => $carry + $discount['amount'],

--- a/tests/php/Service/Akaunting/Document/ProducaoCooperativistaTest.php
+++ b/tests/php/Service/Akaunting/Document/ProducaoCooperativistaTest.php
@@ -76,7 +76,7 @@ final class ProducaoCooperativistaTest extends TestCase
         $this->dates->setInicio(new DateTime('2026-04-01 00:00:00'));
     }
 
-    public function testUpdateLiquidDiscountsSumsLatestMatchPerChildCategory(): void
+    public function testUpdateLiquidDiscountsSumsAllMatchingBillsInSameChildCategory(): void
     {
         $this->persistLiquidDiscountCategoryHierarchy();
 
@@ -111,7 +111,7 @@ final class ProducaoCooperativistaTest extends TestCase
         $document = $this->createDocumentForCooperado(self::COOPERADO_NOME, self::COOPERADO_CPF);
         $document->updateLiquidDiscounts();
 
-        $this->assertSame(64.67, round($document->getValues()->getLiquidDiscount(), 2));
+        $this->assertSame(77.01, round($document->getValues()->getLiquidDiscount(), 2));
     }
 
     public function testUpdateLiquidDiscountsFallsBackToOlderBillInSameCategoryWhenLatestCpfDoesNotMatch(): void


### PR DESCRIPTION
## Summary
- sum all matching liquid discount bills for a cooperator instead of keeping only the latest bill per child category
- add regression coverage for duplicate bills in the same liquid discount child category

## Validation
- ran `phpunit -c tests/php/phpunit.xml tests/php/Service/Akaunting/Document --no-coverage --fail-on-warning --fail-on-risky`
- verified `/api/v1/producao?ano-mes=2026-04` now returns `liquid_discount = 1672.59` for Vitor Mattos