### PR TITLE
Move dependents sourcing from Kimai to Nextcloud

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -112,6 +112,8 @@ PROFILE_FIELDS_AUTH_TOKEN=
 PROFILE_FIELDS_WEIGHT_FIELD_KEY=weight
 # Chave do campo no Profile Fields que guarda o CPF/CNPJ do cooperado
 PROFILE_FIELDS_TAX_NUMBER_FIELD_KEY=tax_number
+# Chave do campo no Profile Fields que guarda a quantidade de dependentes
+PROFILE_FIELDS_DEPENDENTS_FIELD_KEY=dependents
 
 # Nome da prefeitura a importar dados no mês
 PREFEITURA=niteroi

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Calcular o bruto da produção cooperativista por cooperado com base em dados co
 | ---------------------------------- | --------------------------------------------------------------------------------------------------------- |
 | [Kimai](https://www.kimai.org)     | Registro de horas trabalhadas por projeto, emissão de relatório de horas trabalhadas para clientes        |
 | [Akaunting](https://akaunting.com) | Gestão financeira                                                                                         |
-| [Nextcloud + Profile Fields](https://github.com/LibreCodeCoop/profile_fields/) | Diretório interno dos cooperados com os campos customizados `weight` e `tax_number` usados na produção |
+| [Nextcloud + Profile Fields](https://github.com/LibreCodeCoop/profile_fields/) | Diretório interno dos cooperados com os campos customizados `weight`, `tax_number` e `dependents` usados na produção |
 | Site da prefeitura                 | Emissão de NFSe. Hoje o sistema dá suporte oficial apenas as prefeituras dos municípios do Rio e Niterói. |
 
 ## Ambiente de desenvolvimento
@@ -55,8 +55,8 @@ E peça o `.env` de prod ao time de infraestrutura. Irão te passar sem as crede
   * Definir a descrição da nota fiscal com campos separados por `:` (dois pontos)
   * Quando for NFSe para mais de um setor de um mesmo CNPJ, acrescentar o campo `setor: <setor>`
 * Nextcloud + Profile Fields
-  * Criar no app `profile_fields` os campos `weight` e `tax_number`.
-  * Preencher estes campos para cada cooperado; eles passam a ser a fonte oficial do peso e do CPF/CNPJ usados no cálculo.
+  * Criar no app `profile_fields` os campos `weight`, `tax_number` e `dependents`.
+  * Preencher estes campos para cada cooperado; eles passam a ser a fonte oficial do peso, do CPF/CNPJ e da quantidade de dependentes usados no cálculo.
 * Akaunting
   * Dados de clientes
     * Definir número de identificação fiscal (cpf/cnpj) para todo fornecedor/cliente. Quando houver nota emitida para mais de um setor de um mesmo CNPJ e figurarem diferentes contas na LibreCode (conta = contrato), concatenar da seguinte forma: `<cpf/CNPJ>|<setor>`

--- a/src/Service/Kimai/Source/Users.php
+++ b/src/Service/Kimai/Source/Users.php
@@ -124,7 +124,7 @@ class Users
     private function updateFromUserPreferences(array $item): array
     {
         $detailed = $this->doRequestKimai('/users/' . $item['id']);
-        $preferences = array_column($detailed['preferences'], 'value', 'name');
+        $preferences = array_column($detailed['preferences'] ?? [], 'value', 'name');
         $item['kimai_username'] = $item['username'];
         if (!$item['alias']) {
             $item['alias'] = $item['username'];
@@ -133,7 +133,7 @@ class Users
         if ($preferences['tax_number'] ?? '' !== '') {
             $item['tax_number'] = $preferences['tax_number'];
         }
-        $item['dependents'] = (int) ($preferences['dependents'] ?? 0);
+        $item['dependents'] = 0;
         return $item;
     }
 

--- a/src/Service/Nextcloud/ProfileFieldsClient.php
+++ b/src/Service/Nextcloud/ProfileFieldsClient.php
@@ -126,24 +126,84 @@ class ProfileFieldsClient
             return $user;
         }
 
-        $fields = $this->getFieldsForTaxNumber($taxNumber);
+        $fields = $this->resolveFieldsForUser($user, $taxNumber);
         if ($fields === []) {
             return $user;
         }
 
-        $taxNumberFieldKey = $this->getTaxNumberFieldKey();
-        $taxNumber = $fields[$taxNumberFieldKey] ?? null;
-        if (is_scalar($taxNumber) && trim((string) $taxNumber) !== '') {
-            $user['tax_number'] = trim((string) $taxNumber);
+        return $this->applyFieldsToUser($user, $fields);
+    }
+
+    /**
+     * @param array<string, mixed> $user
+     * @return array<string, mixed>
+     */
+    private function resolveFieldsForUser(array $user, string $taxNumber): array
+    {
+        $fields = $this->getFieldsForTaxNumber($taxNumber);
+        if ($fields !== []) {
+            return $fields;
         }
 
-        $weightFieldKey = $this->getWeightFieldKey();
-        $weight = $fields[$weightFieldKey] ?? null;
-        if (is_scalar($weight) && is_numeric((string) $weight)) {
-            $user['peso'] = (float) $weight;
+        $userUid = $this->getUserUid($user);
+        if ($userUid !== '') {
+            $this->logger->debug('Profile Fields lookup by tax number returned no result; falling back to user UID lookup.', [
+                'tax_number' => $taxNumber,
+                'user_uid' => $userUid,
+            ]);
         }
+
+        return $this->getFieldsForUser($userUid);
+    }
+
+    /**
+     * @param array<string, mixed> $user
+     * @param array<string, mixed> $fields
+     * @return array<string, mixed>
+     */
+    private function applyFieldsToUser(array $user, array $fields): array
+    {
+        $this->applyTrimmedScalarField($user, $fields, $this->getTaxNumberFieldKey(), 'tax_number');
+        $this->applyNumericField($user, $fields, $this->getWeightFieldKey(), 'peso', static fn ($value): float => (float) $value);
+        $this->applyNumericField($user, $fields, $this->getDependentsFieldKey(), 'dependents', static fn ($value): int => (int) $value);
 
         return $user;
+    }
+
+    /**
+     * @param array<string, mixed> $user
+     */
+    private function applyTrimmedScalarField(array &$user, array $fields, string $fieldKey, string $userKey): void
+    {
+        $fieldValue = $fields[$fieldKey] ?? null;
+        if (!is_scalar($fieldValue)) {
+            return;
+        }
+
+        $normalizedValue = trim((string) $fieldValue);
+        if ($normalizedValue !== '') {
+            $user[$userKey] = $normalizedValue;
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $user
+     * @param callable(scalar): int|float $caster
+     */
+    private function applyNumericField(array &$user, array $fields, string $fieldKey, string $userKey, callable $caster): void
+    {
+        $fieldValue = $fields[$fieldKey] ?? null;
+        if (is_scalar($fieldValue) && is_numeric((string) $fieldValue)) {
+            $user[$userKey] = $caster($fieldValue);
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $user
+     */
+    private function getUserUid(array $user): string
+    {
+        return trim((string) ($user['kimai_username'] ?? $user['username'] ?? ''));
     }
 
     private function getDefinitionFieldKey(int $definitionId): ?string
@@ -262,5 +322,10 @@ class ProfileFieldsClient
     private function getWeightFieldKey(): string
     {
         return trim((string) getenv('PROFILE_FIELDS_WEIGHT_FIELD_KEY')) ?: 'weight';
+    }
+
+    private function getDependentsFieldKey(): string
+    {
+        return trim((string) getenv('PROFILE_FIELDS_DEPENDENTS_FIELD_KEY')) ?: 'dependents';
     }
 }

--- a/tests/php/Service/Nextcloud/ProfileFieldsClientTest.php
+++ b/tests/php/Service/Nextcloud/ProfileFieldsClientTest.php
@@ -19,6 +19,7 @@ final class ProfileFieldsClientTest extends TestCase
         putenv('PROFILE_FIELDS_AUTH_TOKEN');
         putenv('PROFILE_FIELDS_TAX_NUMBER_FIELD_KEY');
         putenv('PROFILE_FIELDS_WEIGHT_FIELD_KEY');
+        putenv('PROFILE_FIELDS_DEPENDENTS_FIELD_KEY');
     }
 
     public function testGetFieldsForTaxNumberMapsValuesByFieldKey(): void
@@ -163,6 +164,185 @@ final class ProfileFieldsClientTest extends TestCase
             'kimai_username' => 'vitor@librecode.coop',
             'tax_number' => '11122233344',
             'peso' => 1.75,
+        ], $client->enrichUser([
+            'id' => 2,
+            'username' => 'vitor@librecode.coop',
+            'kimai_username' => 'vitor@librecode.coop',
+            'tax_number' => '11122233344',
+        ]));
+    }
+
+    public function testEnrichUserMapsDependentsFromProfileFields(): void
+    {
+        putenv('PROFILE_FIELDS_API_BASE_URL=https://nextcloud.example.com');
+        putenv('PROFILE_FIELDS_AUTH_USER=api-user');
+        putenv('PROFILE_FIELDS_AUTH_TOKEN=api-token');
+
+        $httpClient = new MockHttpClient(function (string $method, string $url, array $options): MockResponse {
+            if (str_ends_with($url, '/users/lookup')) {
+                self::assertSame('POST', $method);
+                self::assertLookupPayload($options, [
+                    'fieldKey' => 'tax_number',
+                    'fieldValue' => '11122233344',
+                ]);
+
+                return new MockResponse((string) json_encode([
+                    'ocs' => [
+                        'meta' => [
+                            'status' => 'ok',
+                            'statuscode' => 100,
+                        ],
+                        'data' => [
+                            'user_uid' => 'pessoa02',
+                            'lookup_field_key' => 'tax_number',
+                            'fields' => [
+                                'tax_number' => [
+                                    'definition' => [
+                                        'field_key' => 'tax_number',
+                                    ],
+                                    'value' => [
+                                        'field_definition_id' => 10,
+                                        'value' => [
+                                            'value' => '11122233344',
+                                        ],
+                                    ],
+                                ],
+                                'dependents' => [
+                                    'definition' => [
+                                        'field_key' => 'dependents',
+                                    ],
+                                    'value' => [
+                                        'field_definition_id' => 11,
+                                        'value' => [
+                                            'value' => '3',
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ]));
+            }
+
+            return new MockResponse('not found', ['http_code' => 404]);
+        });
+
+        $client = new ProfileFieldsClient($httpClient, new NullLogger());
+
+        self::assertSame([
+            'id' => 2,
+            'username' => 'vitor@librecode.coop',
+            'kimai_username' => 'vitor@librecode.coop',
+            'tax_number' => '11122233344',
+            'dependents' => 3,
+        ], $client->enrichUser([
+            'id' => 2,
+            'username' => 'vitor@librecode.coop',
+            'kimai_username' => 'vitor@librecode.coop',
+            'tax_number' => '11122233344',
+        ]));
+    }
+
+    public function testEnrichUserFallsBackToUserUidWhenTaxNumberLookupReturnsNoResult(): void
+    {
+        putenv('PROFILE_FIELDS_API_BASE_URL=https://nextcloud.example.com');
+        putenv('PROFILE_FIELDS_AUTH_USER=api-user');
+        putenv('PROFILE_FIELDS_AUTH_TOKEN=api-token');
+
+        $httpClient = new MockHttpClient(function (string $method, string $url, array $options): MockResponse {
+            if (str_ends_with($url, '/users/lookup')) {
+                self::assertSame('POST', $method);
+                self::assertLookupPayload($options, [
+                    'fieldKey' => 'tax_number',
+                    'fieldValue' => '11122233344',
+                ]);
+
+                return new MockResponse((string) json_encode([
+                    'ocs' => [
+                        'meta' => [
+                            'status' => 'failure',
+                            'statuscode' => 404,
+                            'message' => 'not found',
+                        ],
+                        'data' => [
+                            'message' => 'not found',
+                        ],
+                    ],
+                ]), ['http_code' => 404]);
+            }
+
+            if (str_ends_with($url, '/users/vitor%40librecode.coop/values')) {
+                self::assertSame('GET', $method);
+
+                return new MockResponse((string) json_encode([
+                    'ocs' => [
+                        'meta' => [
+                            'status' => 'ok',
+                            'statuscode' => 100,
+                        ],
+                        'data' => [
+                            [
+                                'field_definition_id' => 10,
+                                'value' => [
+                                    'value' => '11122233344',
+                                ],
+                            ],
+                            [
+                                'field_definition_id' => 11,
+                                'value' => [
+                                    'value' => '1.5',
+                                ],
+                            ],
+                            [
+                                'field_definition_id' => 12,
+                                'value' => [
+                                    'value' => '2',
+                                ],
+                            ],
+                        ],
+                    ],
+                ]));
+            }
+
+            if (str_ends_with($url, '/definitions')) {
+                self::assertSame('GET', $method);
+
+                return new MockResponse((string) json_encode([
+                    'ocs' => [
+                        'meta' => [
+                            'status' => 'ok',
+                            'statuscode' => 100,
+                        ],
+                        'data' => [
+                            [
+                                'id' => 10,
+                                'field_key' => 'tax_number',
+                            ],
+                            [
+                                'id' => 11,
+                                'field_key' => 'weight',
+                            ],
+                            [
+                                'id' => 12,
+                                'field_key' => 'dependents',
+                            ],
+                        ],
+                    ],
+                ]));
+            }
+
+            return new MockResponse('not found', ['http_code' => 404]);
+        });
+
+        $client = new ProfileFieldsClient($httpClient, new NullLogger());
+
+        self::assertSame([
+            'id' => 2,
+            'username' => 'vitor@librecode.coop',
+            'kimai_username' => 'vitor@librecode.coop',
+            'tax_number' => '11122233344',
+            'peso' => 1.5,
+            'dependents' => 2,
         ], $client->enrichUser([
             'id' => 2,
             'username' => 'vitor@librecode.coop',


### PR DESCRIPTION
## Summary
- stop reading `dependents` from Kimai user preferences during user import
- enrich users with `dependents` from Nextcloud Profile Fields while keeping the UID fallback when tax number lookup misses
- document the new Profile Fields setup and add regression coverage for the enrichment flow

## Validation
- run `tests/php/Service/Nextcloud/ProfileFieldsClientTest.php`
- verify signed commit history with one commit per file